### PR TITLE
Feature/ci restructuring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,89 +1,19 @@
-name: CI/CD Pipeline
+name: CI Pipeline
 
 on:
   push:
     branches:
-      - main
-    paths-ignore:
-      - "**/helm/kube-networkpolicy-denier/Chart.yaml"
-    # Move to positive matches later
-    #paths:
-    #  - "**/cmd"
-    #  - "**/helm"
-    #  - "**Dockerfile"
-    #  - "**go.mod"
-    #  - "**go.sum"
+      - "feature/*"
+  workflow_call:
+    secrets:
+      token:
+        required: true
 
 jobs:
-  test-build-publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - id: pre-step
-        name: Docker Version Tag
-        shell: bash
-        run: echo "release_tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: "^1.21.4"
-
-      - name: Go Test and Helm Lint
-        run: make test
-
-      - name: Start Minikube
-        uses: medyagh/setup-minikube@master
-      - name: Cluster connectivity
-        run: kubectl get pods -A
-      - name: Build image, deploy Helm Chart and test in Minikube
-        run: |
-          export SHELL=/bin/bash
-          make github
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          target: release
-          tags: torbendury/kube-networkpolicy-denier:${{ steps.pre-step.outputs.release_tag }},torbendury/kube-networkpolicy-denier:latest
-
-      - name: Update Helm chart appVersion
-        run: |
-          yq e ".appVersion = \"${{ steps.pre-step.outputs.release_tag }}\"" -i ./helm/kube-networkpolicy-denier/Chart.yaml
-        shell: bash
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Bump appVersion to ${{ steps.pre-step.outputs.release_tag }}
-          commit_user_name: GitHub Actions
-          commit_user_email: github-actions@github.com
-          commit_author: GitHub Actions <github-actions@github.com>
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
-
-      - name: Release Helm Chart
-        uses: helm/chart-releaser-action@v1.6.0
-        with:
-          charts_dir: helm
-          skip_existing: true
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  # call e2etest and unittest workflows in local repo in parallel
+  unittest:
+    uses: ./.github/workflows/unittest.yml
+    secrets: inherit
+  e2etest:
+    uses: ./.github/workflows/e2etest.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,37 @@ on:
     branches:
       - "feature/*"
   workflow_call:
+    outputs:
+      overall-result:
+        description: "Overall test result"
+        value: ${{ jobs.report.outputs.overall-result }}
 
 jobs:
-  # call e2etest and unittest workflows in local repo in parallel
   unittest:
     uses: ./.github/workflows/unittest.yml
     secrets: inherit
+
   e2etest:
     uses: ./.github/workflows/e2etest.yml
     secrets: inherit
+
+  report:
+    needs: [unittest, e2etest]
+    runs-on: ubuntu-latest
+    outputs:
+      overall-result: ${{ steps.check.outputs.result }}
+    steps:
+      - name: Check test results
+        uses: ./.github/workflows/report.yml
+        with:
+          unittest-result: ${{ needs.unittest.outputs.test-result }}
+          e2etest-result: ${{ needs.e2etest.outputs.test-result }}
+
+      - name: Set overall result
+        id: check
+        run: |
+          if [[ "${{ needs.unittest.outputs.test-result }}" == "success" && "${{ needs.e2etest.outputs.test-result }}" == "0" ]]; then
+            echo "::set-output name=result::success"
+          else
+            echo "::set-output name=result::failure"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - "feature/*"
   workflow_call:
-    secrets:
-      token:
-        required: true
 
 jobs:
   # call e2etest and unittest workflows in local repo in parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,6 @@ jobs:
     outputs:
       overall-result: ${{ steps.check.outputs.result }}
     steps:
-      - name: Check test results
-        uses: ./.github/workflows/report.yml
-        with:
-          unittest-result: ${{ needs.unittest.outputs.test-result }}
-          e2etest-result: ${{ needs.e2etest.outputs.test-result }}
-
       - name: Set overall result
         id: check
         run: |

--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -2,9 +2,6 @@ name: CI Pipeline
 
 on:
   workflow_call:
-    secrets:
-      token:
-        required: true
 
 jobs:
   e2e_test:

--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -2,10 +2,16 @@ name: CI Pipeline
 
 on:
   workflow_call:
+    outputs:
+      test-result:
+        description: "Test result"
+        value: ${{ jobs.e2e_test.outputs.test-result }}
 
 jobs:
   e2e_test:
     runs-on: ubuntu-latest
+    outputs:
+      test-result: ${{ steps.test.outputs.result }}
 
     steps:
       - name: Checkout code
@@ -18,9 +24,13 @@ jobs:
 
       - name: Start Minikube
         uses: medyagh/setup-minikube@master
+
       - name: Cluster connectivity
         run: kubectl get pods -A
+
       - name: Build image, deploy Helm Chart and test in Minikube
+        id: test
         run: |
           export SHELL=/bin/bash
-          make github
+          TEST_RESULT=$(make github)
+          echo "::set-output name=result::$TEST_RESULT"

--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -1,0 +1,29 @@
+name: CI Pipeline
+
+on:
+  workflow_call:
+    secrets:
+      token:
+        required: true
+
+jobs:
+  e2e_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.21.4"
+
+      - name: Start Minikube
+        uses: medyagh/setup-minikube@master
+      - name: Cluster connectivity
+        run: kubectl get pods -A
+      - name: Build image, deploy Helm Chart and test in Minikube
+        run: |
+          export SHELL=/bin/bash
+          make github

--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -32,5 +32,6 @@ jobs:
         id: test
         run: |
           export SHELL=/bin/bash
-          TEST_RESULT=$(make github)
+          make github
+          TEST_RESULT=$?
           echo "::set-output name=result::$TEST_RESULT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,18 +35,6 @@ jobs:
         with:
           go-version: "^1.21.4"
 
-      - name: Go Test and Helm Lint
-        run: make test
-
-      - name: Start Minikube
-        uses: medyagh/setup-minikube@master
-      - name: Cluster connectivity
-        run: kubectl get pods -A
-      - name: Build image, deploy Helm Chart and test in Minikube
-        run: |
-          export SHELL=/bin/bash
-          make github
-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/helm/kube-networkpolicy-denier/Chart.yaml"
+    # Move to positive matches later
+    #paths:
+    #  - "**/cmd"
+    #  - "**/helm"
+    #  - "**Dockerfile"
+    #  - "**go.mod"
+    #  - "**go.sum"
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+  build_publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - id: pre-step
+        name: Docker Version Tag
+        shell: bash
+        run: echo "release_tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.21.4"
+
+      - name: Go Test and Helm Lint
+        run: make test
+
+      - name: Start Minikube
+        uses: medyagh/setup-minikube@master
+      - name: Cluster connectivity
+        run: kubectl get pods -A
+      - name: Build image, deploy Helm Chart and test in Minikube
+        run: |
+          export SHELL=/bin/bash
+          make github
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          target: release
+          tags: torbendury/kube-networkpolicy-denier:${{ steps.pre-step.outputs.release_tag }},torbendury/kube-networkpolicy-denier:latest
+
+      - name: Update Helm chart appVersion
+        run: |
+          yq e ".appVersion = \"${{ steps.pre-step.outputs.release_tag }}\"" -i ./helm/kube-networkpolicy-denier/Chart.yaml
+        shell: bash
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Bump appVersion to ${{ steps.pre-step.outputs.release_tag }}
+          commit_user_name: GitHub Actions
+          commit_user_email: github-actions@github.com
+          commit_author: GitHub Actions <github-actions@github.com>
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Release Helm Chart
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: helm
+          skip_existing: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
   build_publish:
+    needs: ci
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,9 +2,6 @@ name: CI Pipeline
 
 on:
   workflow_call:
-    secrets:
-      token:
-        required: true
 
 jobs:
   unit_tests:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,10 +2,16 @@ name: CI Pipeline
 
 on:
   workflow_call:
+    outputs:
+      test-result:
+        description: "Test result"
+        value: ${{ jobs.unit_tests.outputs.test-result }}
 
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
+    outputs:
+      test-result: ${{ steps.test.outputs.result }}
 
     steps:
       - name: Checkout code
@@ -17,4 +23,7 @@ jobs:
           go-version: "^1.21.4"
 
       - name: Go Test and Helm Lint
-        run: make test
+        id: test
+        run: |
+          make test
+          echo "::set-output name=result::success"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,23 @@
+name: CI Pipeline
+
+on:
+  workflow_call:
+    secrets:
+      token:
+        required: true
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.21.4"
+
+      - name: Go Test and Helm Lint
+        run: make test


### PR DESCRIPTION
The full-fledged CI workflow was split up to:

- Run unit and e2e tests on feature/* branches
- Run full CI on `main` commits, which includes that tests must succeed
- Parallelize unit and e2e tests