### PR TITLE
feat: shorten time interval for liveness and readiness probe

### DIFF
--- a/helm/kube-networkpolicy-denier/templates/deployment.yaml
+++ b/helm/kube-networkpolicy-denier/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               port: https
               scheme: HTTPS
             initialDelaySeconds: 2
-            periodSeconds: 5
+            periodSeconds: 2
             failureThreshold: 2
             successThreshold: 1
           readinessProbe:
@@ -63,8 +63,8 @@ spec:
               port: https
               scheme: HTTPS
             initialDelaySeconds: 2
-            periodSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 2
+            failureThreshold: 2
             successThreshold: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
The liveness probe used to only check every 5 seconds if the container is able to serve traffic. This lead to the fact that Kubernetes would only stop traffic to the container after ~10 seconds which is unacceptable. Also, the readiness probe now fails faster and checks in a shorter interval.

This closes #10.