### PR TITLE
ci: introduce changelog generation with git-chglog

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,42 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/torbendury/kube-networkpolicy-denier
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,9 @@ repos:
       - id: go-lint
       - id: go-unit-tests
       - id: go-static-check # install https://staticcheck.io/docs/
+  - repo: local
+    hooks:
+      - id: changelog
+        language: system
+        name: Changelog
+        entry: /bin/bash -c 'docker run -u 1000:1000 --rm -v $(pwd):/workdir quay.io/git-chglog/git-chglog > CHANGELOG.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Chore
+- CHANGELOG
 - typo
 - **core:** move admission UID retrieval ([#14](https://github.com/torbendury/kube-networkpolicy-denier/issues/14))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 
 ### Chore
 - typo
+- **core:** move admission UID retrieval ([#14](https://github.com/torbendury/kube-networkpolicy-denier/issues/14))
 
 ### Ci
+- introduce changelog generation with git-chglog It has been bugging me for some time now that releases of the Helm Chart are quite ambiguous. Future Helm Chart releases will include a link to the latest changelog. Users will now also be informed about unreleased features which will make it into the upcoming release. Additionally, if I don't want to blow up release changelogs in the future, I will need to squash commits more often.
+- introduce changelog generation with git-chglog It has been bugging me for some time now that releases of the Helm Chart are quite ambiguous. Future Helm Chart releases will include a link to the latest changelog. Users will now also be informed about unreleased features which will make it into the upcoming release. Additionally, if I don't want to blow up release changelogs in the future, I will need to squash commits more often.
 - rename separate pipelines
 - remove gh-pages sync
 - automatic resolve of conflicts
@@ -24,6 +27,9 @@
 - correct Make handling
 - correct diff exit code handling
 - integration/e2e test for helm chart Installing the Helm Chart and testing it against a Kubernetes cluster by applying a NetworkPolicy was a manual task until now. From now on, these steps will be done on every push to main automatically. Also, after a successful release, gh-pages branch will be automatically kept in-sync with main. Before, GitHub Actions denied triggering the pages CI to prevent recursion.
+
+### Feat
+- shorten time interval for liveness and readiness probe ([#12](https://github.com/torbendury/kube-networkpolicy-denier/issues/12))
 
 
 <a name="kube-networkpolicy-denier-0.1.0"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,151 @@
+<a name="unreleased"></a>
+## [Unreleased]
+
+### Chore
+- typo
+
+### Ci
+- rename separate pipelines
+- remove gh-pages sync
+- automatic resolve of conflicts
+- checkout separate main
+- sync gh-pages with main
+- explicit merge
+- fast forward pull
+- explicit pull of branches
+- merge instead of rebase
+- explicit branch handling
+- rebase strategy
+- rebase instead of merge
+- allow unrelated main-gh-pages sync
+- correct sync between main and gh-pages
+- step naming
+- skip existing helm chart version This bothered me for a while now, because not every CI run includes a new Helm release. However, main should be able to produce a release at every time and thus the goal is to keep CI green.
+- correct Make handling
+- correct diff exit code handling
+- integration/e2e test for helm chart Installing the Helm Chart and testing it against a Kubernetes cluster by applying a NetworkPolicy was a manual task until now. From now on, these steps will be done on every push to main automatically. Also, after a successful release, gh-pages branch will be automatically kept in-sync with main. Before, GitHub Actions denied triggering the pages CI to prevent recursion.
+
+
+<a name="kube-networkpolicy-denier-0.1.0"></a>
+## [kube-networkpolicy-denier-0.1.0] - 2023-11-29
+### Doc
+- several status badges
+- refine resource usage
+- versioning advisory Added documentation for the projects' versioning approach. The Helm Chart uses SemVer and always contains a working and tested version of the controller. The controller image is still built with every pushed commit and is tested separately, so: a) not every image version will make it into a Helm release b) not every Helm release is expected to work with any version of the controller. Also added a quick hit on the supported and tested Kubernetes versions after some historical research on API releases by Kubernetes.
+
+### Feat
+- set default message on module load This is most due to the fact that unit tests - among other non-'main function'-invokers will not parse any actual flags to the 'respMsg'.
+- **core:** allow custom response message The response message should be configurable for administrators. It provides a value that matches the past behavior and can be controlled via Helm values. If the message is empty, the response is handled by Kubernetes which tells the user that the controller denied the request without further explanation.
+
+
+<a name="kube-networkpolicy-denier-0.0.5"></a>
+## [kube-networkpolicy-denier-0.0.5] - 2023-11-25
+### Chore
+- bump helm chart version
+- TODOs moved to GitHub Issues for better visibility of the projects state
+
+### Ci
+- introduce pre-commit hooks Writing code can be hard, so I want to take as much of the burden out of my brain as possible. pre-commit hooks allow me to implement ideas and still maintain a certain minimum level of standards that I might otherwise overlook. This commit introduces a set of pre-commit hooks I initially chose. They seem to work out for me and did not find anything worth a mention initially. However, the hooks run quite fast (<5s, faster than I can remember some of my Makefile steps) and don't stop me from committing fast.
+- action for syncing gh-pages with main
+
+### Feat
+- **core:** timeout handling Golang net/http does not provide default timeouts, and so didn't the admission controller. Server timeouts for header/body reads and write as well as connection keepalive timeouts were defined and tested, as well as handler-specific timeouts were implemented. The handlers now listen on the handed request context which gets cancelled after a handler-specific time. The benchmark tests have been adjusted so we can handle big load situations. At about 15k req/s, the server starts to throw errors which I will have to investigate later.
+- **helm:** faster readiness and liveness feedback loop
+
+### Test
+- better grown and sufficient load testing
+
+
+<a name="kube-networkpolicy-denier-0.0.4"></a>
+## [kube-networkpolicy-denier-0.0.4] - 2023-11-23
+### Chore
+- Helm Chart version
+
+### Ci
+- use negative matches on CI events
+- ignore non-code and non-ci relevant repos for builds
+- **make:** helm chart version
+
+### Doc
+- repo doc prettifying and helm chart doc adjustments
+
+### Feat
+- **core:** stop logging healthcheck requests In [#2](https://github.com/torbendury/kube-networkpolicy-denier/issues/2), I initially wanted to make health check logging optional. Now that I hat some time to think and investigate, the optimal solution would have been to implement a second optional handler which gets registered at start (depending on health-check logging being on/off). The overhead for the solution would have been to big, so I removed the logging functionatility frmo the health check completely.
+
+### Testing
+- add basic perf benchmarks
+
+
+<a name="kube-networkpolicy-denier-0.0.3"></a>
+## [kube-networkpolicy-denier-0.0.3] - 2023-11-23
+### Chore
+- conflict
+
+### Ci
+- **helm:** set resource namespace
+- **make:** faster local testing with minikube and chained build
+
+### Fix
+- **core:** gracefully handle shutdowns When terminating Pods, Kubernetes sends a SIGTERM to the process. The net/http server running in the container did not handle such signals. Now, a goroutine in the background is listening for SIGTERM signals and tries to stop the server gracefully before the Pod is shutdown. This prevents flaky API calls from the Kubernetes apiserver and lets existing connections finish before the server is shutdown.
+
+
+<a name="kube-networkpolicy-denier-0.0.2"></a>
+## [kube-networkpolicy-denier-0.0.2] - 2023-11-22
+### Chore
+- update TODOs
+
+### Ci
+- refactor Makefile
+- **helm:** adjust minor helm parts - Chart version for testing update - test Pod to use HTTPS and ignore the selfsigned cert - resource recommendation for cpu/mem
+
+### Doc
+- repo README adjustments
+- Helm Chart installation commands
+
+### Feat
+- improve logging with deeper information
+
+### Hack
+- add simple networkpolicy for testing
+
+
+<a name="kube-networkpolicy-denier-0.0.1"></a>
+## kube-networkpolicy-denier-0.0.1 - 2023-11-22
+### Chore
+- TODOs
+- update TODOs
+- TODOs
+
+### Ci
+- build only release target in multi-stage docker build
+- remove unneccesary git installation git seems to be installed in the ubuntu container anyway
+- add helm chart linting to test section and push tags, docker containers and helm charts
+- set github token for chart releaser as env var
+- use correct chart-releaser config
+- remove explicit chart repo url
+- configure git
+- rely on git short commit hash as release tag
+- **gh-action:** configure newer version of chart releaser
+- **gh-action:** use different action for version bumping and add release mechanism
+- **gh-action:** newer version of chart releaser
+- **github-actions:** initial throw
+- **helm:** correct NOTES include
+- **helm:** readme, notes, cleanup
+- **helm:** first working helm chart
+
+### Doc
+- repo README
+- code documentation for all function signatures
+
+### Feat
+- Initial commit This introduces my new project for experimenting with admission controllers in Kubernetes. It provides a very easy and understandable way of denying new NetworkPolicies by using the Kubernetes API. One does not need to touch the apiserver directly but can use the interface and effectively deny all new NetworkPolicies in the Kubernetes cluster. This can be adapted to basically every scenario.
+- **Dockerfile:** refine build stage to correctly download third party modules
+- **core:** logging and correct API implementation Implement some very basic logging for startup, errors and incoming requests. Since my first run of this on a minikube cluster and a deeper glance at the ValidationWebhookConfiguration API, I found out that it is not sufficient to just return a non-200 status code but one has to correctly implement the AdmissionReview API. I did this in the easiest + fastest possible way for now.
+
+
+[Unreleased]: https://github.com/torbendury/kube-networkpolicy-denier/compare/kube-networkpolicy-denier-0.1.0...HEAD
+[kube-networkpolicy-denier-0.1.0]: https://github.com/torbendury/kube-networkpolicy-denier/compare/kube-networkpolicy-denier-0.0.5...kube-networkpolicy-denier-0.1.0
+[kube-networkpolicy-denier-0.0.5]: https://github.com/torbendury/kube-networkpolicy-denier/compare/kube-networkpolicy-denier-0.0.4...kube-networkpolicy-denier-0.0.5
+[kube-networkpolicy-denier-0.0.4]: https://github.com/torbendury/kube-networkpolicy-denier/compare/kube-networkpolicy-denier-0.0.3...kube-networkpolicy-denier-0.0.4
+[kube-networkpolicy-denier-0.0.3]: https://github.com/torbendury/kube-networkpolicy-denier/compare/kube-networkpolicy-denier-0.0.2...kube-networkpolicy-denier-0.0.3
+[kube-networkpolicy-denier-0.0.2]: https://github.com/torbendury/kube-networkpolicy-denier/compare/kube-networkpolicy-denier-0.0.1...kube-networkpolicy-denier-0.0.2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 A very basic **admission controller** for Kubernetes that denies all network policies. It works as a validation webhook and can be used to prevent users from creating network policies. This is especially useful in multi-tenant clusters where you want to prevent users from creating network policies that might affect other users, or (like in my case) in environments where you exclusively rely on Istio AuthorizationPolicies.
 
+See the full changelog [here](https://github.com/torbendury/kube-networkpolicy-denier/blob/main/CHANGELOG.md)
+
 ## 🚀 Installation / Deployment
 
 See the [README for the Helm Chart](helm/kube-networkpolicy-denier/README.md) for more information.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,23 +72,18 @@ func validateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go func() {
-		// Read the admission review request
-
 		infoLogger.Println(r.URL.Path, " name: ", admissionReview.Request.Name, " namespace: ", admissionReview.Request.Namespace, " operation: ", admissionReview.Request.Operation, " uid: ", admissionReview.Request.UID)
 
-		// Get the UID from the AdmissionRequest
-		uid := admissionReview.Request.UID
-
-		// Create the admission review response
+		// Create the admission response
 		admissionResponse := admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Message: *respMsg,
 			},
-			UID: uid,
+			UID: admissionReview.Request.UID,
 		}
 
-		// Create the admission review response review
+		// Create the admission review response
 		admissionReviewResponse := admissionv1.AdmissionReview{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "admission.k8s.io/v1",

--- a/helm/kube-networkpolicy-denier/Chart.yaml
+++ b/helm/kube-networkpolicy-denier/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kube-networkpolicy-denier
-description: An admission controller that denies all NetworkPolicy objects.
+description: An admission controller that denies all NetworkPolicy objects. See the changelog at https://github.com/torbendury/kube-networkpolicy-denier/blob/main/CHANGELOG.md
 type: application
 version: 0.1.0
 appVersion: "e8e5b7b"

--- a/helm/kube-networkpolicy-denier/Chart.yaml
+++ b/helm/kube-networkpolicy-denier/Chart.yaml
@@ -3,4 +3,4 @@ name: kube-networkpolicy-denier
 description: An admission controller that denies all NetworkPolicy objects.
 type: application
 version: 0.1.0
-appVersion: "b5cedab"
+appVersion: "e8e5b7b"

--- a/helm/kube-networkpolicy-denier/README.md
+++ b/helm/kube-networkpolicy-denier/README.md
@@ -4,6 +4,8 @@ This chart installs a admission controller on a Kubernetes cluster using the Hel
 
 It effectively denies all NetworkPolicies from being created on the cluster.
 
+See changes [here](https://github.com/torbendury/kube-networkpolicy-denier/blob/main/CHANGELOG.md)
+
 ## 📜 Source Code
 
 You can find the source code of this chart on [GitHub](https://github.com/torbendury/kube-networkpolicy-denier).

--- a/helm/kube-networkpolicy-denier/templates/deployment.yaml
+++ b/helm/kube-networkpolicy-denier/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               port: https
               scheme: HTTPS
             initialDelaySeconds: 2
-            periodSeconds: 5
+            periodSeconds: 2
             failureThreshold: 2
             successThreshold: 1
           readinessProbe:
@@ -63,8 +63,8 @@ spec:
               port: https
               scheme: HTTPS
             initialDelaySeconds: 2
-            periodSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 2
+            failureThreshold: 2
             successThreshold: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
It has been bugging me for some time now that releases of the Helm Chart are quite ambiguous. Future Helm Chart releases will include a link to the latest changelog. Users will now also be informed about unreleased features which will make it into the upcoming release. Additionally, if I don't want to blow up release changelogs in the future, I will need to squash commits more often.

This is an outcome of #9. I'm not 100% happy with it at the moment but it eases my mind about releases.