### PR TITLE
chore(core): move admission UID retrieval

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,23 +72,18 @@ func validateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go func() {
-		// Read the admission review request
-
 		infoLogger.Println(r.URL.Path, " name: ", admissionReview.Request.Name, " namespace: ", admissionReview.Request.Namespace, " operation: ", admissionReview.Request.Operation, " uid: ", admissionReview.Request.UID)
 
-		// Get the UID from the AdmissionRequest
-		uid := admissionReview.Request.UID
-
-		// Create the admission review response
+		// Create the admission response
 		admissionResponse := admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Message: *respMsg,
 			},
-			UID: uid,
+			UID: admissionReview.Request.UID,
 		}
 
-		// Create the admission review response review
+		// Create the admission review response
 		admissionReviewResponse := admissionv1.AdmissionReview{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "admission.k8s.io/v1",


### PR DESCRIPTION
also correct minor documentation issue.
The UID retrieval is most probably optimized away on build time but it makes it more clear where the UID is actually being used. No need for a separate variable.