### PR TITLE
feat(docker): minify image size

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.21.4"
+          go-version: "^1.21.5"
 
       - name: Start Minikube
         uses: medyagh/setup-minikube@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.21.4"
+          go-version: "^1.21.5"
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.21.4"
+          go-version: "^1.21.5"
 
       - name: Go Test and Helm Lint
         id: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 ## [Unreleased]
 
 ### Chore
-- CHANGELOG
 - typo
 - **core:** move admission UID retrieval ([#14](https://github.com/torbendury/kube-networkpolicy-denier/issues/14))
 
 ### Ci
-- introduce changelog generation with git-chglog It has been bugging me for some time now that releases of the Helm Chart are quite ambiguous. Future Helm Chart releases will include a link to the latest changelog. Users will now also be informed about unreleased features which will make it into the upcoming release. Additionally, if I don't want to blow up release changelogs in the future, I will need to squash commits more often.
-- introduce changelog generation with git-chglog It has been bugging me for some time now that releases of the Helm Chart are quite ambiguous. Future Helm Chart releases will include a link to the latest changelog. Users will now also be informed about unreleased features which will make it into the upcoming release. Additionally, if I don't want to blow up release changelogs in the future, I will need to squash commits more often.
+- introduce changelog generation with git-chglog ([#13](https://github.com/torbendury/kube-networkpolicy-denier/issues/13))
 - rename separate pipelines
 - remove gh-pages sync
 - automatic resolve of conflicts

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dev:
 ### Build the release container
 # This is not used in the CI/CD pipeline!
 build:
-> docker build --no-cache -t $(RELEASE_IMAGE_NAME):latest --target release .
+> docker build --no-cache -t $(RELEASE_IMAGE_NAME):latest --target minified .
 
 ### Create local test cluster
 # This is not used in the CI/CD pipeline!

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/torbendury/kube-networkpolicy-denier
 
-go 1.21.4
+go 1.21.5
 
 require (
 	k8s.io/api v0.28.4

--- a/helm/kube-networkpolicy-denier/templates/deployment.yaml
+++ b/helm/kube-networkpolicy-denier/templates/deployment.yaml
@@ -38,8 +38,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /app/app
           args:
             - --cert=/certs/tls.crt
             - --key=/certs/tls.key


### PR DESCRIPTION
Now, the application runs on Golang 1.21.5 with a least privilege user (essentially nobody) on a scratch container. 

The container only includes the application, the user information and SSL certificates.

I also included verification of Go modules for security.

A minor improvement also includes a set entrypoint for the image, so the Kubernetes Deployment does no longer need to explicitly call the application including its path.

This solves #5.